### PR TITLE
Including otpion for ECal digitized hits

### DIFF
--- a/plotting/drawhits.py
+++ b/plotting/drawhits.py
@@ -65,7 +65,7 @@ def parse_args():
     parser.add_argument('-z','--bin_width_z',
                     type=int, default=None,
                     help='bin width for z in mm')
-    parser.add_argument('-a', '--bin_width_phi',
+    parser.add_argument('--bin_width_phi',
                     type=float, default=None,
                     help='bin width for azimuthal angle phi')
     parser.add_argument('--stat_box',

--- a/plotting/drawhits.py
+++ b/plotting/drawhits.py
@@ -179,14 +179,8 @@ detector_type = detector_dict["typeFlag"]
 print("Retrieve the number of cells per layer")
 layer_cells = {}
 n_tot_cells = 0
-for de, cells in detector_dict["det_element_cells"].items():
-    #for ECalBArrel take the cell from bath - TODO: improve code clarity if possible
-    if de == 'bath':
-        layer_cells[0] = cells
-        n_tot_cells += cells
-
-    ln = layer_number_from_string(de)
-
+for det_element, cells in detector_dict["det_element_cells"].items():
+    ln = layer_number_from_string(det_element)
     layer_cells[ln] = cells
     n_tot_cells += cells
 

--- a/plotting/drawhits.py
+++ b/plotting/drawhits.py
@@ -209,7 +209,7 @@ assumptions = load_json(assumptions_path, sub_detector) if assumptions_path else
 
 if (e_cut or digi) and assumptions == None:
     raise ValueError(f"Given the input settings (e_cut={e_cut}, digi={digi})," +
-                     "an 'assumption' JSON is needed as input")
+                     "an 'assumptions' JSON is needed as input (-a/--assumptions <assumptions.json>)")
 
 # Set the energy thresholds, if required
 E_thr_MeV = 0
@@ -280,6 +280,7 @@ h_particle_ID.SetCanExtend(ROOT.TH1.kAllAxes)   # Allow both axes to extend past
 
 histograms += [
     h_avg_hits_x_layer := ROOT.TH1D("h_avg_hits_x_layer_"+collection, "h_avg_hits_x_layer_"+collection, *layer_binning),
+    h_avg_firing_cells_x_layer := ROOT.TH1D("h_avg_firing_cells_x_layer_"+collection, "h_avg_firing_cells_x_layer_"+collection, *layer_binning),
     h_avg_occ_x_layer := ROOT.TH1D("h_avg_occ_x_layer_"+collection, "h_avg_occ_x_layer_"+collection, *layer_binning),
 ]
 
@@ -426,6 +427,8 @@ for i,event in enumerate(podio_reader.get(tree_name)):
             h_hit_E_MeV.Fill(E_hit, fill_weight)
             h_hit_E_keV.Fill(E_hit * 1e3, fill_weight)
             h_avg_hits_x_layer.Fill(layer_n, fill_weight)
+            if not cell_fired:
+                h_avg_firing_cells_x_layer.Fill(layer_n, fill_weight)
 
             hist_zr.Fill(z_mm, r_mm, fill_weight)
             hist_xy.Fill(x_mm, y_mm, fill_weight)
@@ -532,7 +535,8 @@ if draw_hists:
     draw_hist(h_hit_E_keV, "Deposited energy [keV]", "Hits / events",  sample_name+"_hit_E_keV_"+str(n_events)+"evt_"+sub_detector, collection)
     draw_hist(h_hit_t, "Timing [ns]", "Hits / events",  sample_name+"_hit_t_"+str(n_events)+"evt_"+sub_detector, collection)
     draw_hist(h_hit_t_corr, "Timing - TOF [ns]", "Hits / events",  sample_name+"_hit_t_corr_"+str(n_events)+"evt_"+sub_detector, collection)
-    draw_hist(h_avg_hits_x_layer, "Layer number", "Hits / events",  sample_name+"_hits_x_layer_"+str(n_events)+"evt_"+sub_detector, collection)
+    draw_hist(h_avg_hits_x_layer, "Layer number", "Hits / events",  sample_name+"_avg_hits_x_layer_"+str(n_events)+"evt_"+sub_detector, collection)
+    draw_hist(h_avg_firing_cells_x_layer, "Layer number", "Firing cells / events",  sample_name+"_avg_firing_cells_x_layer_"+str(n_events)+"evt_"+sub_detector, collection)
     draw_hist(h_avg_occ_x_layer, "Layer number", "Average occupancy [%]",  sample_name+"_avg_occ_x_layer_"+str(n_events)+"evt_"+sub_detector, collection, log_y=False)
     draw_hist(h_occ, "Occupancy [%]", "Entries / events",  sample_name+f"_occ_tot_"+str(n_events)+"evt_"+sub_detector, collection, log_x=True)
 

--- a/plotting/drawhits.py
+++ b/plotting/drawhits.py
@@ -326,7 +326,7 @@ podio_reader = root_io.Reader(list_input_files)
 # Check if collection is valid and setup a cell ID decoder
 metadata = podio_reader.get("metadata")[0]
 
-id_encoding = metadata.get_parameter(detector_dict["hitsCollection"]+"__CellIDEncoding")
+id_encoding = metadata.get_parameter(collection+"__CellIDEncoding") #detector_dict["hitsCollection"]
 decoder = ROOT.dd4hep.BitFieldCoder(id_encoding)
 #print("HERE",decoder.fieldDescription()) #get possible values
 

--- a/plotting/drawhits.py
+++ b/plotting/drawhits.py
@@ -450,61 +450,11 @@ for i,event in enumerate(podio_reader.get(tree_name)):
         # Apply cut deposited energy
         if E_hit >= E_hit_thr or (not e_cut):
 
-
-<<<<<<< HEAD
             x_mm = hit.getPosition().x
             y_mm = hit.getPosition().y
             z_mm = hit.getPosition().z
             r_mm = math.sqrt(math.pow(x_mm, 2) + math.pow(y_mm, 2))
             phi = math.acos(x_mm/r_mm) * math.copysign(1, y_mm)
-
-            if(debug>1): print(" cell_id:", cell_id, " layer_n:", layer_n, " x_mm:", x_mm, " y_mm:", y_mm, " z_mm:", z_mm, " r_mm:", r_mm, " phi:", phi)
-=======
-        # Fill the hits histograms
-        h_hit_x_mm.Fill(x_mm, fill_weight)
-        h_hit_y_mm.Fill(y_mm, fill_weight)
-        h_hit_z_mm.Fill(z_mm, fill_weight)
-        h_hit_r_mm.Fill(r_mm, fill_weight)
-        h_hit_E_MeV.Fill(E_hit, fill_weight)
-        h_hit_E_keV.Fill(E_hit * 1e3, fill_weight)
-        h_avg_hits_x_layer.Fill(layer_n, fill_weight)
-
-        hist_zr.Fill(z_mm, r_mm, fill_weight)
-        hist_xy.Fill(x_mm, y_mm, fill_weight)
-        hist_zphi.Fill(z_mm, phi, fill_weight)
-
-        h_hit_t.Fill(t, fill_weight)
-        h_hit_t_x_layer.Fill(t, layer_n, fill_weight)
-
-        h_hit_t_corr.Fill(t - (hit_distance / C_MM_NS), fill_weight)
-
-        if layer_cells:
-            h_z_density_vs_layer_mm[layer_n].Fill(z_mm, fill_weight)
-            h_phi_density_vs_layer[layer_n].Fill(phi, fill_weight)
-            h_zphi_density_vs_layer[layer_n].Fill(z_mm, phi, fill_weight)
-
-            if energy_per_layer:
-                h_hit_E_MeV_x_layer[layer_n].Fill(E_hit, fill_weight)
-
-        if not is_calo_hit:
-            particle = hit.getParticle()
-
-            particle_p4 = ROOT.Math.LorentzVector('ROOT::Math::PxPyPzM4D<double>')(particle.getMomentum().x, particle.getMomentum().y, particle.getMomentum().z, particle.getMass())
-
-            # Fill MC particle histograms
-            h_particle_E.Fill(particle_p4.E(), fill_weight)
-            h_particle_pt.Fill(particle_p4.pt(), fill_weight)
-            h_particle_eta.Fill(particle_p4.eta(), fill_weight)
-            h_particle_ID.Fill(str(particle.getPDG()), fill_weight)
-
-        # Monitor in channels that are integrating signal
-        if integration_time > 1:
-            if ((layer_n, cell_id) in integrating_channels) and (integrating_channels[layer_n, cell_id] > 1):
-
-                # count one hit per event during integration time as pileup
-                if not cell_fired:
-                    pile_up_counter[layer_n, cell_id] += 1
->>>>>>> 6ca534023c601efa12dd3e4238058a73c67f42ed
 
             if is_calo_hit:
                 t = -999  # Timing not available for MutableSimCalorimeterHit
@@ -519,6 +469,8 @@ for i,event in enumerate(podio_reader.get(tree_name)):
             # For layer percentage occupancy, count cells only once
             if not cell_fired:
                 fired_cells_x_layer[layer_n] += 1
+
+            if(debug>1): print(" cell_id:", cell_id, " layer_n:", layer_n, " x_mm:", x_mm, " y_mm:", y_mm, " z_mm:", z_mm, " r_mm:", r_mm, " phi:", phi)
 
             # Fill the hits histograms
             h_hit_x_mm.Fill(x_mm, fill_weight)

--- a/plotting/hits2bw.py
+++ b/plotting/hits2bw.py
@@ -5,7 +5,7 @@ import re
 
 import ROOT
 
-from helpers import load_json, layer_number_from_string
+from helpers import load_json, simplify_dict
 from constants import b_to_GB, MHz_to_Hz
 from visualization import setup_root_style, draw_hist
 
@@ -50,15 +50,6 @@ ROOT.gErrorIgnoreLevel = ROOT.kWarning
 
 #######################################
 # functions
-
-def simplify_dict(d):
-    """
-    Simplify dict keys to match only the layer number
-    """ 
-    old_keys = list(d.keys())
-    for k in old_keys:
-        d[layer_number_from_string(k)] = d.pop(k)
-    return d
 
 
 #######################################

--- a/python/helpers.py
+++ b/python/helpers.py
@@ -96,3 +96,13 @@ def layer_number_from_string(layer_string):
         ln *= side
     
     return ln
+
+
+def simplify_dict(d):
+    """
+    Simplify dict keys to match only the layer number
+    """ 
+    old_keys = list(d.keys())
+    for k in old_keys:
+        d[layer_number_from_string(k)] = d.pop(k)
+    return d

--- a/templates/ALLEGRO_o1_v03_assumptions.json
+++ b/templates/ALLEGRO_o1_v03_assumptions.json
@@ -37,7 +37,7 @@
     "modifiers": {
       "n_samples": 1
     },
-    "digitized_hits": "EMBCaloTopoClusterCells",
+    "digitized_hits": "ECalBarrelModuleThetaMergedPositioned",
     "E_thr_MeV": {
       "layer0": 0.14,
       "layer1": 0.15,

--- a/templates/ALLEGRO_o1_v03_assumptions.json
+++ b/templates/ALLEGRO_o1_v03_assumptions.json
@@ -37,19 +37,22 @@
     "modifiers": {
       "n_samples": 1
     },
-    "digitized_hits": "ECalBarrelModuleThetaMergedPositioned",
-    "E_thr_MeV": {
-      "layer0": 0.14,
-      "layer1": 0.15,
-      "layer2": 0.16,
-      "layer3": 0.18,
-      "layer4": 0.20,
-      "layer5": 0.22,
-      "layer6": 0.23,
-      "layer7": 0.26,
-      "layer8": 0.28,
-      "layer9": 0.30,
-      "layer10": 0.32
+
+    "digitized_hits": {
+      "collection": "ECalBarrelModuleThetaMergedPositioned",
+      "E_thr_MeV": {
+        "layer0": 0.36,
+        "layer1": 1.1,
+        "layer2": 1.16,
+        "layer3": 1.2,
+        "layer4": 1.3,
+        "layer5": 1.4,
+        "layer6": 1.5,
+        "layer7": 1.6,
+        "layer8": 1.7,
+        "layer9": 1.8,
+        "layer10": 1.9
+      }
     }
   }
 }

--- a/templates/ALLEGRO_o1_v03_assumptions.json
+++ b/templates/ALLEGRO_o1_v03_assumptions.json
@@ -29,5 +29,27 @@
     "modifiers": {
       "n_samples": 400
     }
+  },
+
+  "ECalBarrel": {
+    "strategy": "hit_counts",
+    "hit_size": 2,
+    "modifiers": {
+      "n_samples": 1
+    },
+    "digitized_hits": "EMBCaloTopoClusterCells",
+    "E_thr_MeV": {
+      "layer0": 0.14,
+      "layer1": 0.15,
+      "layer2": 0.16,
+      "layer3": 0.18,
+      "layer4": 0.20,
+      "layer5": 0.22,
+      "layer6": 0.23,
+      "layer7": 0.26,
+      "layer8": 0.28,
+      "layer9": 0.30,
+      "layer10": 0.32
+    }
   }
 }


### PR DESCRIPTION
Changes needed to process digitized hits from the ECal.

This also includes a flag to enable an energy cut, which is to be defined in the `assumptions` JSON. This choice is to keep track of what should be the default E cut per hits collection, instead of having to pass values on CLI, and this also helps when the R threshold is to be defined per layer.

Maybe @meleneemil can have a quick look, just to be sure I haven't screwed up any recent changes.