### PR TITLE
Improving plotting and adding hit rate and pixel occupancy plots for vertex detector and silicon wrapper

### DIFF
--- a/detectors_dicts/ALLEGRO_o1_v03_DetectorDimensions.json
+++ b/detectors_dicts/ALLEGRO_o1_v03_DetectorDimensions.json
@@ -295,8 +295,8 @@
       "layer_1_side0": 385920.0
     },
     "sensors_per_module_map": {
-      "layer_0_side0": 1.0,
-      "layer_1_side0": 1.0
+      "layer_0_side0": 1,
+      "layer_1_side0": 1
     },
     "max_z": 2400,
     "max_r": 2950
@@ -318,10 +318,10 @@
       "layer2": 9342.480000000001
     },
     "sensors_per_module_map": {
-      "layer-1": 1.0,
-      "layer-2": 1.0,
-      "layer1": 1.0,
-      "layer2": 1.0
+      "layer-1": 1,
+      "layer-2": 1,
+      "layer1": 1,
+      "layer2": 1
     },
     "max_z": 2340,
     "max_r": 2890
@@ -345,11 +345,11 @@
       "layer_4_side0": 368.2800000000001
     },
     "sensors_per_module_map": {
-      "layer_0_side0": 1.0,
-      "layer_1_side0": 1.0,
-      "layer_2_side0": 1.0,
-      "layer_3_side0": 4.0,
-      "layer_4_side0": 4.0
+      "layer_0_side0": 1,
+      "layer_1_side0": 1,
+      "layer_2_side0": 1,
+      "layer_3_side0": 4,
+      "layer_4_side0": 4
     },
     "max_z": 360,
     "max_r": 470
@@ -375,12 +375,12 @@
       "layer3": 368.2800000000001
     },
     "sensors_per_module_map": {
-      "layer-1": 4.0,
-      "layer-2": 4.0,
-      "layer-3": 4.0,
-      "layer1": 4.0,
-      "layer2": 4.0,
-      "layer3": 4.0
+      "layer-1": 4,
+      "layer-2": 4,
+      "layer-3": 4,
+      "layer1": 4,
+      "layer2": 4,
+      "layer3": 4
     },
     "max_z": 950,
     "max_r": 420

--- a/detectors_dicts/ALLEGRO_o1_v03_DetectorDimensions.json
+++ b/detectors_dicts/ALLEGRO_o1_v03_DetectorDimensions.json
@@ -117,6 +117,8 @@
       "DCH_v2_layer99DE": 768,
       "DCH_v2_layer9DE": 240
     },
+    "sensor_size_map": {},
+    "sensors_per_module_map": {},
     "max_z": 2250,
     "max_r": 2850
   },
@@ -137,6 +139,8 @@
       "layer9": 142080,
       "layer10": 142080
     },
+    "sensor_size_map": {},
+    "sensors_per_module_map": {},
     "max_z": 3100,
     "max_r": 3850
   },
@@ -152,6 +156,8 @@
       "wheel3": 462400,
       "wheel-3": 462400
     },
+    "sensor_size_map": {},
+    "sensors_per_module_map": {},
     "max_z": 3850,
     "max_r": 4110
   },
@@ -178,6 +184,8 @@
       "layer8": 310,
       "layer9": 310
     },
+    "sensor_size_map": {},
+    "sensors_per_module_map": {},
     "max_z": 2800,
     "max_r": 6370
   },
@@ -189,6 +197,8 @@
       "layer_-1": 2275,
       "layer_1": 2275
     },
+    "sensor_size_map": {},
+    "sensors_per_module_map": {},
     "max_z": 5450,
     "max_r": 6370
   },
@@ -200,6 +210,8 @@
       "Calorimeter1": 1,
       "Calorimeter2": 1
     },
+    "sensor_size_map": {},
+    "sensors_per_module_map": {},
     "max_z": 1190,
     "max_r": 160
   },
@@ -211,6 +223,8 @@
       "Calorimeter1": 1,
       "Calorimeter2": 1
     },
+    "sensor_size_map": {},
+    "sensors_per_module_map": {},
     "max_z": 1200,
     "max_r": 210
   },
@@ -222,6 +236,8 @@
       "Calorimeter1": 1,
       "Calorimeter2": 1
     },
+    "sensor_size_map": {},
+    "sensors_per_module_map": {},
     "max_z": 1190,
     "max_r": 210
   },
@@ -233,6 +249,8 @@
       "Calorimeter1": 1,
       "Calorimeter2": 1
     },
+    "sensor_size_map": {},
+    "sensors_per_module_map": {},
     "max_z": 1190,
     "max_r": 190
   },
@@ -244,6 +262,8 @@
       "layer0": 157696.0,
       "layer1": 157696.0
     },
+    "sensor_size_map": {},
+    "sensors_per_module_map": {},
     "max_z": 6000,
     "max_r": 7080
   },
@@ -257,6 +277,8 @@
       "layer1": 78848.0,
       "layer2": 78848.0
     },
+    "sensor_size_map": {},
+    "sensors_per_module_map": {},
     "max_z": 6000,
     "max_r": 6370
   },
@@ -268,17 +290,13 @@
       "layer_0_side0": 151,
       "layer_1_side0": 151
     },
-    "cell_size": {
+    "sensor_size_map": {
       "layer_0_side0": 385920.0,
       "layer_1_side0": 385920.0
     },
-    "pixel_size_u": {
+    "sensors_per_module_map": {
       "layer_0_side0": 1.0,
       "layer_1_side0": 1.0
-    },
-    "pixel_size_v": {
-      "layer_0_side0": 0.05,
-      "layer_1_side0": 0.05
     },
     "max_z": 2400,
     "max_r": 2950
@@ -288,28 +306,22 @@
     "typeFlag": 265,
     "hitsCollection": "SiWrDCollection",
     "det_element_cells": {
-      "layer-2": 1244,
       "layer-1": 1284,
+      "layer-2": 1244,
       "layer1": 1284,
       "layer2": 1244
     },
-    "cell_size": {
-      "layer-2": 2862.24,
-      "layer-1": 2862.24,
-      "layer1": 2862.24,
-      "layer2": 2862.24
+    "sensor_size_map": {
+      "layer-1": 9342.480000000001,
+      "layer-2": 9342.480000000001,
+      "layer1": 9342.480000000001,
+      "layer2": 9342.480000000001
     },
-    "pixel_size_u": {
-      "layer-2": 1.0,
+    "sensors_per_module_map": {
       "layer-1": 1.0,
+      "layer-2": 1.0,
       "layer1": 1.0,
       "layer2": 1.0
-    },
-    "pixel_size_v": {
-      "layer-2": 0.05,
-      "layer-1": 0.05,
-      "layer1": 0.05,
-      "layer2": 0.05
     },
     "max_z": 2340,
     "max_r": 2890
@@ -322,36 +334,22 @@
       "layer_0_side0": 90,
       "layer_1_side0": 240,
       "layer_2_side0": 540,
-      "layer_3_side0": 184,
-      "layer_4_side0": 816
+      "layer_3_side0": 736,
+      "layer_4_side0": 3264
     },
-    "cell_size": {
-      "layer_0_side0": 204.8,
-      "layer_1_side0": 204.8,
-      "layer_2_side0": 204.8,
-      "layer_3_side0": 1473.12,
-      "layer_4_side0": 1473.12
+    "sensor_size_map": {
+      "layer_0_side0": 204.80000000000004,
+      "layer_1_side0": 204.80000000000004,
+      "layer_2_side0": 204.80000000000004,
+      "layer_3_side0": 368.2800000000001,
+      "layer_4_side0": 368.2800000000001
     },
-    "pixel_size_u": {
-      "layer_0_side0": 0.025,
-      "layer_1_side0": 0.025,
-      "layer_2_side0": 0.025,
-      "layer_3_side0": 0.150,
-      "layer_4_side0": 0.150
-    },
-    "pixel_size_v": {
-      "layer_0_side0": 0.025,
-      "layer_1_side0": 0.025,
-      "layer_2_side0": 0.025,
-      "layer_3_side0": 0.050,
-      "layer_4_side0": 0.050
-    },
-    "sensors_per_module": {
-      "layer_0_side0": 1,
-      "layer_1_side0": 1,
-      "layer_2_side0": 1,
-      "layer_3_side0": 1,
-      "layer_4_side0": 1
+    "sensors_per_module_map": {
+      "layer_0_side0": 1.0,
+      "layer_1_side0": 1.0,
+      "layer_2_side0": 1.0,
+      "layer_3_side0": 4.0,
+      "layer_4_side0": 4.0
     },
     "max_z": 360,
     "max_r": 470
@@ -361,36 +359,28 @@
     "typeFlag": 329,
     "hitsCollection": "VertexEndcapCollection",
     "det_element_cells": {
-      "layer-3": 216,
-      "layer-2": 248,
-      "layer-1": 244,
-      "layer1": 244,
-      "layer2": 248,
-      "layer3": 216
+      "layer-1": 976,
+      "layer-2": 992,
+      "layer-3": 864,
+      "layer1": 976,
+      "layer2": 992,
+      "layer3": 864
     },
-    "cell_size": {
-      "layer_-3": 1473.12,
-      "layer_-2": 1473.12,
-      "layer_-1": 1473.12,
-      "layer_1": 1473.12,
-      "layer_2": 1473.12,
-      "layer_3": 1473.12
+    "sensor_size_map": {
+      "layer-1": 368.2800000000001,
+      "layer-2": 368.2800000000001,
+      "layer-3": 368.2800000000001,
+      "layer1": 368.2800000000001,
+      "layer2": 368.2800000000001,
+      "layer3": 368.2800000000001
     },
-    "pixel_size_u": {
-      "layer_-3_side0": 0.150,
-      "layer_-2_side0": 0.150,
-      "layer_-1_side0": 0.150,
-      "layer_1_side0": 0.150,
-      "layer_2_side0": 0.150,
-      "layer_3_side0": 0.150
-    },
-    "pixel_size_v": {
-      "layer_-3_side0": 0.050,
-      "layer_-2_side0": 0.050,
-      "layer_-1_side0": 0.050,
-      "layer_1_side0": 0.050,
-      "layer_2_side0": 0.050,
-      "layer_3_side0": 0.050
+    "sensors_per_module_map": {
+      "layer-1": 4.0,
+      "layer-2": 4.0,
+      "layer-3": 4.0,
+      "layer1": 4.0,
+      "layer2": 4.0,
+      "layer3": 4.0
     },
     "max_z": 950,
     "max_r": 420

--- a/detectors_dicts/ALLEGRO_o1_v03_DetectorDimensions.json
+++ b/detectors_dicts/ALLEGRO_o1_v03_DetectorDimensions.json
@@ -295,7 +295,9 @@
     },
     "det_element_size": {
       "layer-2": 2862.24,
-      "layer-1": 2862.24
+      "layer-1": 2862.24,
+      "layer1": 2862.24,
+      "layer2": 2862.24
     },
     "det_element_pixel_size_u": {
       "layer-2": 1.0,

--- a/detectors_dicts/ALLEGRO_o1_v03_DetectorDimensions.json
+++ b/detectors_dicts/ALLEGRO_o1_v03_DetectorDimensions.json
@@ -265,8 +265,20 @@
     "typeFlag": 273,
     "hitsCollection": "SiWrBCollection",
     "det_element_cells": {
-      "layer0": 20000,
-      "layer1": 20000
+      "layer0_side0": 151,
+      "layer1_side0": 151
+    },
+    "det_element_size": {
+      "layer_0_side0": 385920.0,
+      "layer_1_side0": 385920.0
+    },
+    "det_element_pixel_size_u": {
+      "layer_0_side0": 1.0,
+      "layer_1_side0": 1.0
+    },
+    "det_element_pixel_size_v": {
+      "layer_0_side0": 0.05,
+      "layer_1_side0": 0.05
     },
     "max_z": 2400,
     "max_r": 2950
@@ -276,10 +288,26 @@
     "typeFlag": 265,
     "hitsCollection": "SiWrDCollection",
     "det_element_cells": {
-      "layer-2": 7500,
-      "layer-1": 7500,
-      "layer1": 7500,
-      "layer2": 7500
+      "layer-2": 1244,
+      "layer-1": 1284,
+      "layer1": 1284,
+      "layer2": 1244
+    },
+    "det_element_size": {
+      "layer-2": 2862.24,
+      "layer-1": 2862.24
+    },
+    "det_element_pixel_size_u": {
+      "layer-2": 1.0,
+      "layer-1": 1.0,
+      "layer1": 1.0,
+      "layer2": 1.0
+    },
+    "det_element_pixel_size_v": {
+      "layer-2": 0.05,
+      "layer-1": 0.05,
+      "layer1": 0.05,
+      "layer2": 0.05
     },
     "max_z": 2340,
     "max_r": 2890
@@ -292,8 +320,36 @@
       "layer_0_side0": 90,
       "layer_1_side0": 240,
       "layer_2_side0": 540,
-      "layer_3_side0": 736,
-      "layer_4_side0": 3264
+      "layer_3_side0": 184,
+      "layer_4_side0": 816
+    },
+    "det_element_size": {
+      "layer_0_side0": 204.8,
+      "layer_1_side0": 204.8,
+      "layer_2_side0": 204.8,
+      "layer_3_side0": 1473.12,
+      "layer_4_side0": 1473.12
+    },
+    "det_element_pixel_size_u": {
+      "layer_0_side0": 0.025,
+      "layer_1_side0": 0.025,
+      "layer_2_side0": 0.025,
+      "layer_3_side0": 0.150,
+      "layer_4_side0": 0.150
+    },
+    "det_element_pixel_size_v": {
+      "layer_0_side0": 0.025,
+      "layer_1_side0": 0.025,
+      "layer_2_side0": 0.025,
+      "layer_3_side0": 0.050,
+      "layer_4_side0": 0.050
+    },
+    "sensors_per_module": {
+      "layer_0_side0": 1,
+      "layer_1_side0": 1,
+      "layer_2_side0": 1,
+      "layer_3_side0": 1,
+      "layer_4_side0": 1
     },
     "max_z": 360,
     "max_r": 470
@@ -303,12 +359,27 @@
     "typeFlag": 329,
     "hitsCollection": "VertexEndcapCollection",
     "det_element_cells": {
-      "layer-1": 976,
-      "layer-2": 992,
-      "layer-3": 864,
-      "layer1": 976,
-      "layer2": 992,
-      "layer3": 864
+      "layer-1": 244,
+      "layer-2": 248,
+      "layer-3": 216,
+      "layer1": 244,
+      "layer2": 248,
+      "layer3": 216
+    },
+    "det_element_size": {
+      "layer_1_side0": 1473.12,
+      "layer_2_side0": 1473.12,
+      "layer_3_side0": 1473.12
+    },
+    "det_element_pixel_size_u": {
+      "layer_1_side0": 0.150,
+      "layer_2_side0": 0.150,
+      "layer_3_side0": 0.150
+    },
+    "det_element_pixel_size_v": {
+      "layer_1_side0": 0.050,
+      "layer_2_side0": 0.050,
+      "layer_3_side0": 0.050
     },
     "max_z": 950,
     "max_r": 420

--- a/detectors_dicts/ALLEGRO_o1_v03_DetectorDimensions.json
+++ b/detectors_dicts/ALLEGRO_o1_v03_DetectorDimensions.json
@@ -265,18 +265,18 @@
     "typeFlag": 273,
     "hitsCollection": "SiWrBCollection",
     "det_element_cells": {
-      "layer0_side0": 151,
-      "layer1_side0": 151
+      "layer_0_side0": 151,
+      "layer_1_side0": 151
     },
-    "det_element_size": {
+    "cell_size": {
       "layer_0_side0": 385920.0,
       "layer_1_side0": 385920.0
     },
-    "det_element_pixel_size_u": {
+    "pixel_size_u": {
       "layer_0_side0": 1.0,
       "layer_1_side0": 1.0
     },
-    "det_element_pixel_size_v": {
+    "pixel_size_v": {
       "layer_0_side0": 0.05,
       "layer_1_side0": 0.05
     },
@@ -293,19 +293,19 @@
       "layer1": 1284,
       "layer2": 1244
     },
-    "det_element_size": {
+    "cell_size": {
       "layer-2": 2862.24,
       "layer-1": 2862.24,
       "layer1": 2862.24,
       "layer2": 2862.24
     },
-    "det_element_pixel_size_u": {
+    "pixel_size_u": {
       "layer-2": 1.0,
       "layer-1": 1.0,
       "layer1": 1.0,
       "layer2": 1.0
     },
-    "det_element_pixel_size_v": {
+    "pixel_size_v": {
       "layer-2": 0.05,
       "layer-1": 0.05,
       "layer1": 0.05,
@@ -325,21 +325,21 @@
       "layer_3_side0": 184,
       "layer_4_side0": 816
     },
-    "det_element_size": {
+    "cell_size": {
       "layer_0_side0": 204.8,
       "layer_1_side0": 204.8,
       "layer_2_side0": 204.8,
       "layer_3_side0": 1473.12,
       "layer_4_side0": 1473.12
     },
-    "det_element_pixel_size_u": {
+    "pixel_size_u": {
       "layer_0_side0": 0.025,
       "layer_1_side0": 0.025,
       "layer_2_side0": 0.025,
       "layer_3_side0": 0.150,
       "layer_4_side0": 0.150
     },
-    "det_element_pixel_size_v": {
+    "pixel_size_v": {
       "layer_0_side0": 0.025,
       "layer_1_side0": 0.025,
       "layer_2_side0": 0.025,
@@ -361,24 +361,33 @@
     "typeFlag": 329,
     "hitsCollection": "VertexEndcapCollection",
     "det_element_cells": {
-      "layer-1": 244,
-      "layer-2": 248,
       "layer-3": 216,
+      "layer-2": 248,
+      "layer-1": 244,
       "layer1": 244,
       "layer2": 248,
       "layer3": 216
     },
-    "det_element_size": {
-      "layer_1_side0": 1473.12,
-      "layer_2_side0": 1473.12,
-      "layer_3_side0": 1473.12
+    "cell_size": {
+      "layer_-3": 1473.12,
+      "layer_-2": 1473.12,
+      "layer_-1": 1473.12,
+      "layer_1": 1473.12,
+      "layer_2": 1473.12,
+      "layer_3": 1473.12
     },
-    "det_element_pixel_size_u": {
+    "pixel_size_u": {
+      "layer_-3_side0": 0.150,
+      "layer_-2_side0": 0.150,
+      "layer_-1_side0": 0.150,
       "layer_1_side0": 0.150,
       "layer_2_side0": 0.150,
       "layer_3_side0": 0.150
     },
-    "det_element_pixel_size_v": {
+    "pixel_size_v": {
+      "layer_-3_side0": 0.050,
+      "layer_-2_side0": 0.050,
+      "layer_-1_side0": 0.050,
       "layer_1_side0": 0.050,
       "layer_2_side0": 0.050,
       "layer_3_side0": 0.050

--- a/detectors_dicts/ALLEGRO_o1_v03_assumptions.json
+++ b/detectors_dicts/ALLEGRO_o1_v03_assumptions.json
@@ -8,6 +8,20 @@
       "layer3": 32,
       "layer4": 32
     },
+    "pixel_size_u": {
+      "layer0": 0.025,
+      "layer1": 0.025,
+      "layer2": 0.025,
+      "layer3": 0.050,
+      "layer4": 0.050
+    },
+    "pixel_size_v": {
+      "layer0": 0.025,
+      "layer1": 0.025,
+      "layer2": 0.025,
+      "layer3": 0.150,
+      "layer4": 0.150
+    },
     "multipliers": {
       "safety_factor": 3,
       "cluster_size": 5
@@ -17,6 +31,22 @@
   "VertexDisks": {
     "strategy": "hit_counts",
     "hit_size": 32,
+    "pixel_size_u": {
+      "layer_-3": 0.050,
+      "layer_-2": 0.050,
+      "layer_-1": 0.050,
+      "layer_1": 0.050,
+      "layer_2": 0.050,
+      "layer_3": 0.050
+    },
+    "pixel_size_v": {
+      "layer_-3": 0.150,
+      "layer_-2": 0.150,
+      "layer_-1": 0.150,
+      "layer_1": 0.150,
+      "layer_2": 0.150,
+      "layer_3": 0.150
+    },
     "multipliers": {
       "safety_factor": 3,
       "cluster_size": 5
@@ -37,6 +67,14 @@
     "multipliers": {
       "safety_factor": 3,
       "cluster_size": 5
+    },
+    "pixel_size_u": {
+      "layer0": 0.050,
+      "layer1": 0.050
+    },
+    "pixel_size_v": {
+      "layer0": 1.000,
+      "layer1": 1.000
     }
   },
 
@@ -46,6 +84,18 @@
     "multipliers": {
       "safety_factor": 3,
       "cluster_size": 5                                                                                                                                                                                                                                                                                                                                                                    
+    },
+    "pixel_size_u": {
+      "layer_-2": 0.050,
+      "layer_-1": 0.050,
+      "layer_1": 0.050,
+      "layer_2": 0.050
+    },
+    "pixel_size_v": {
+      "layer_-2": 1.000,
+      "layer_-1": 1.000,
+      "layer_1": 1.000,
+      "layer_2": 1.000
     }
   },
 

--- a/detectors_dicts/ALLEGRO_o1_v03_assumptions.json
+++ b/detectors_dicts/ALLEGRO_o1_v03_assumptions.json
@@ -8,19 +8,12 @@
       "layer3": 32,
       "layer4": 32
     },
-    "pixel_size_u": {
-      "layer0": 0.025,
-      "layer1": 0.025,
-      "layer2": 0.025,
-      "layer3": 0.050,
-      "layer4": 0.050
-    },
-    "pixel_size_v": {
-      "layer0": 0.025,
-      "layer1": 0.025,
-      "layer2": 0.025,
-      "layer3": 0.150,
-      "layer4": 0.150
+    "pixel_size_uv": {
+      "layer0": [0.025,0.025],
+      "layer1": [0.025,0.025],
+      "layer2": [0.025,0.025],
+      "layer3": [0.050,0.150],
+      "layer4": [0.050,0.150]
     },
     "multipliers": {
       "safety_factor": 3,
@@ -31,21 +24,13 @@
   "VertexDisks": {
     "strategy": "hit_counts",
     "hit_size": 32,
-    "pixel_size_u": {
-      "layer_-3": 0.050,
-      "layer_-2": 0.050,
-      "layer_-1": 0.050,
-      "layer_1": 0.050,
-      "layer_2": 0.050,
-      "layer_3": 0.050
-    },
-    "pixel_size_v": {
-      "layer_-3": 0.150,
-      "layer_-2": 0.150,
-      "layer_-1": 0.150,
-      "layer_1": 0.150,
-      "layer_2": 0.150,
-      "layer_3": 0.150
+    "pixel_size_uv": {
+      "layer_-3": [0.050,0.150],
+      "layer_-2": [0.050,0.150],
+      "layer_-1": [0.050,0.150],
+      "layer_1": [0.050,0.150],
+      "layer_2": [0.050,0.150],
+      "layer_3": [0.050,0.150]
     },
     "multipliers": {
       "safety_factor": 3,
@@ -68,13 +53,9 @@
       "safety_factor": 3,
       "cluster_size": 5
     },
-    "pixel_size_u": {
-      "layer0": 0.050,
-      "layer1": 0.050
-    },
-    "pixel_size_v": {
-      "layer0": 1.000,
-      "layer1": 1.000
+    "pixel_size_uv": {
+      "layer0": [0.050, 1.000],
+      "layer1": [0.050, 1.000]
     }
   },
 
@@ -85,17 +66,11 @@
       "safety_factor": 3,
       "cluster_size": 5                                                                                                                                                                                                                                                                                                                                                                    
     },
-    "pixel_size_u": {
-      "layer_-2": 0.050,
-      "layer_-1": 0.050,
-      "layer_1": 0.050,
-      "layer_2": 0.050
-    },
-    "pixel_size_v": {
-      "layer_-2": 1.000,
-      "layer_-1": 1.000,
-      "layer_1": 1.000,
-      "layer_2": 1.000
+    "pixel_size_uv": {
+      "layer_-2": [0.050,1.000],
+      "layer_-1": [0.050,1.000],
+      "layer_1": [0.050,1.000],
+      "layer_2": [0.050,1.000]
     }
   },
 

--- a/detectors_dicts/ALLEGRO_o1_v03_assumptions.json
+++ b/detectors_dicts/ALLEGRO_o1_v03_assumptions.json
@@ -10,7 +10,7 @@
     },
     "multipliers": {
       "safety_factor": 3,
-      "cluster_size": 2.5
+      "cluster_size": 5
     }
   },
 
@@ -19,7 +19,7 @@
     "hit_size": 32,
     "multipliers": {
       "safety_factor": 3,
-      "cluster_size": 2.5
+      "cluster_size": 5
     }
   },
 

--- a/detectors_dicts/ALLEGRO_o1_v03_assumptions.json
+++ b/detectors_dicts/ALLEGRO_o1_v03_assumptions.json
@@ -2,24 +2,24 @@
   "VertexBarrel": {
     "strategy": "hit_counts",
     "hit_size": {
-      "layer0": 18,
-      "layer1": 18,
-      "layer2": 18,
-      "layer3": 15,
-      "layer4": 15
+      "layer0": 32,
+      "layer1": 32,
+      "layer2": 32,
+      "layer3": 32,
+      "layer4": 32
     },
     "multipliers": {
       "safety_factor": 3,
-      "cluster_size": 5
+      "cluster_size": 2.5
     }
   },
 
   "VertexDisks": {
     "strategy": "hit_counts",
-    "hit_size": 15,
+    "hit_size": 32,
     "multipliers": {
       "safety_factor": 3,
-      "cluster_size": 5
+      "cluster_size": 2.5
     }
   },
 
@@ -28,6 +28,24 @@
     "hit_size": 2,
     "multipliers": {
       "n_samples": 400
+    }
+  },
+
+  "SiWrB": {
+    "strategy": "hit_counts",
+    "hit_size": 64,
+    "multipliers": {
+      "safety_factor": 3,
+      "cluster_size": 5
+    }
+  },
+
+  "SiWrD": {
+    "strategy": "hit_counts",
+    "hit_size": 64,
+    "multipliers": {
+      "safety_factor": 3,
+      "cluster_size": 5                                                                                                                                                                                                                                                                                                                                                                    
     }
   },
 

--- a/plotting/README.md
+++ b/plotting/README.md
@@ -6,7 +6,7 @@ Collections of scripts for making plots from BIB simulated files.
 
 There are 3 scripts in this directory for drawing the hit maps
 - `drawhits.py`: it plots the hit maps and some profile histograms for a given sub-detector.
-- `hits2bw.py`: converts the results from `drawhits` into bandwidth estimations.
+- `hits2highLevelEstimations.py`: converts the results from `drawhits` into bandwidth, hit rate, pixel occupancy and other high-level estimations.
 - **[TO BE FIXED]** `plot_all_subdetectors.py`: it automatically loops over all the sub-detectors and the hit collections, matching them. For each collection/sub-detector it calls the drawhits.py script to plot the hit map.
 
 ### drawhits.py
@@ -60,11 +60,11 @@ drawhits.py -i <path_to_digitized_sim_hits_file> -e 100 -s ECalBarrel --digi --e
 TODO: fill the list above
 
 
-### hits2bw.py
+### hits2highLevelEstimations.py
 
-`hits2bw.py` reads the per-layer hit histograms produced by `drawhits.py`
-and converts hit counts or occupancy into an estimated data bandwidth per layer
-and total bandwidth.
+`hits2highLevelEstimations.py` reads the per-layer and per-cell hit histograms produced by `drawhits.py`
+and converts hit counts or occupancy into an estimated data bandwidth per layer, total bandwidth, 
+hit rate and occupancy per layer and per cell (cell in semiconductor layers being a sensor module).
 The conversion uses a chosen strategy ("hits" or "occupancy"),
 a per-hit size (or per-layer sizes) and optional multipliers 
 from an "assumptions" JSON dictionary, together with the detector channel counts 
@@ -89,7 +89,7 @@ Example:
 drawhits.py -e 100 -s VertexDisks --sample myhits
 
 # then use the its output root file to estimate bandwidths
-hits2bw.py -i myhits_hits_100evt_VertexDisks.root -d $BIB_STUDIES/detectors_dicts/ALLEGRO_o1_v03_DetectorDimensions.json -a $BIB_STUDIES/detectors_dicts/ALLEGRO_o1_v03_assumptions.json
+hits2highLevelEstimations.py -i myhits_hits_100evt_VertexDisks.root -d $BIB_STUDIES/detectors_dicts/ALLEGRO_o1_v03_DetectorDimensions.json -a $BIB_STUDIES/detectors_dicts/ALLEGRO_o1_v03_assumptions.json
 ```
 
 ## Draw particles info

--- a/plotting/README.md
+++ b/plotting/README.md
@@ -37,6 +37,7 @@ Other useful options are:
 - `-a` / `--assumptions` path to the "assumptions" JSON dictionary
 - `--digi` to use digitzed hits (collection defined in the assumptions dict)
 - `--e_cut` to apply the energy cut (threshold defined in the assumptions dict)
+- `--skip_layers` to skip creating and filling histograms per layer, useful for sub-detectors with many layers (e.g. drift chamber)
 
 Use the `-h` / `--help` flag to print all the available arguments.
 
@@ -78,6 +79,7 @@ Key input arguments:
 - `-d` / `--detDictFile` detector dimensions JSON (produced by `xml2json.py`) to get hits collection and per-layer channel counts.
 - `-a` / `--assumptions` JSON with the bandwidth estimation assumptions: strategy (`hit_counts` or `occupancy`), `hit_size` (number or per-layer dict), and `multipliers` (multiplicative factors).
 - `-r` / `--rate` hit rate in MHz used to scale counts to bandwidth.
+- `--hitRateOccPlots` Use to also plot hit rate and occupancies per module in each layer (for vertex detector or silicon wrapper for example)
 
 Notes:
 - The assumptions JSON must define the chosen `strategy` and `hit_size`. If strategy is `occupancy`, number of cells per layer from the detector JSON are used to convert occupancy to absolute counts before applying hit size and rate.

--- a/plotting/drawhits.py
+++ b/plotting/drawhits.py
@@ -571,7 +571,7 @@ if draw_hists:
         for l in h_z_density_vs_layer_mm.keys():
             draw_hist(h_z_density_vs_layer_mm[l], "z [mm]","Hits/event",  sample_name+f"_zDensity_layer{l}_"+str(n_events)+"evt_"+sub_detector, collection)
             draw_hist(h_phi_density_vs_layer[l],  "phi","Hits/event",  sample_name+f"_phiDensity_layer{l}_"+str(n_events)+"evt_"+sub_detector, collection)
-            draw_hist(h_xy_density_vs_layer[l], "x [mm]", "y [mm]", sample_name+f"_xyDensity_layer{l}_"+str(n_events)+"evt_"+sub_detector, collection)
+            draw_hist(h_xy_density_vs_layer[l], "x [mm]", "y [mm]", sample_name+f"_xyDensity_layer{l}_"+str(n_events)+"evt_"+sub_detector, collection, draw_opt="colz")
 
     if integration_time > 1:
         draw_hist(h_tot_pu, "Number of pileup hits", "Entries",  sample_name+"_tot_pu_"+str(n_events)+"evt_"+sub_detector, collection)

--- a/plotting/drawhits.py
+++ b/plotting/drawhits.py
@@ -129,9 +129,9 @@ ROOT.gErrorIgnoreLevel = ROOT.kWarning
 print("Importing detector specific functions for:", det_file.short)
 match det_file.short:
     case "ALLEGRO":
-        from ALLEGRO import get_layer
+        from ALLEGRO import get_layer,get_module,get_sensor
     case "IDEA":
-        from IDEA import get_layer
+        from IDEA import get_layer,get_module,get_sensor
     case "CLD":
         from CLD import get_layer
     case "ILD_FCCee":
@@ -188,6 +188,43 @@ print(">>>",dict(sorted(layer_cells.items())))
 
 n_layers = len(layer_cells.keys())
 
+# Get the size of a channel (i.e. the size of a pixel)
+print("Retrieve the channel size per layer")
+pixel_size_u = {}
+for det_element, pixel_size in detector_dict["det_element_pixel_size_u"].items():
+    ln = layer_number_from_string(det_element)
+    pixel_size_u[ln] = pixel_size
+    print(f" layer {ln}: pixel size u = {pixel_size} mm")
+
+if not pixel_size_u:
+    print("WARNING: map of pixel size in u per layer is empty.")
+
+pixel_size_v = {}
+for det_element, pixel_size in detector_dict["det_element_pixel_size_v"].items():
+    ln = layer_number_from_string(det_element)
+    pixel_size_v[ln] = pixel_size
+    print(f" layer {ln}: pixel size v = {pixel_size} mm")
+
+if not pixel_size_v:
+    print("WARNING: map of pixel size in v per layer is empty.")
+
+# sensors_per_module = {}
+# for det_element, nsensors in detector_dict["sensors_per_module"].items():
+#     ln = layer_number_from_string(det_element)
+#     sensors_per_module[ln] = nsensors
+#     print(f" layer {ln}: pixel size v = {nsensors} mm")
+
+# Calculate channels per cell (i.e. pixel per sensitive element)
+# channels_per_cell = {}
+# for ln in cell_size.keys():
+#     try:
+#         channels_per_cell[ln] = int(round(cell_size[ln] / (pixel_size_u[ln] * pixel_size_v[ln])))   # Ensure it's an ingeger number
+#     except KeyError:
+#         print(f"WARNING: missing pixel size or cell size info for layer {ln}, cannot compute channels per cell. Setting it to 1.")
+#         channels_per_cell[ln] = 1
+# print("Channels per cell per layer:", channels_per_cell)
+
+
 if (e_cut or digi) and assumptions == None:
     raise ValueError(f"Given the input settings (e_cut={e_cut}, digi={digi})," +
                      "an 'assumptions' JSON is needed as input (-a/--assumptions <assumptions.json>)")
@@ -239,7 +276,7 @@ r_binning = [int(r_range * 2 / bw_r), -r_range, r_range]  # mm binning
 phi_binning = [int(phi_range * 2 / bw_phi), -phi_range, phi_range ] # rad binning
 if debug>1: print(f"z_binning: {z_binning}, r_binning: {r_binning}, phi_binning: {phi_binning}")
 
-layer_binning = [n_layers + 1, -0.5, n_layers + 0.5]
+layer_binning = [n_layers+1, -0.5, n_layers + 0.5]
 if is_endcap(detector_type):
     max_l = int(n_layers / 2) + 0.5
     layer_binning = [n_layers + 1, -max_l, +max_l]
@@ -307,11 +344,45 @@ for l in layer_cells.keys():
     h_zphi_density_vs_layer[l] = ROOT.TH2D(f"hist_zphi_vs_layer{l}"+collection, f"hist_zphi_vs_layer{l}"+collection+"; ; ; hits/(%1.2f#times%d)rad#timesmm per event"%(bw_phi,bw_z), *z_binning, *phi_binning)
     histograms += [h_z_density_vs_layer_mm[l], h_phi_density_vs_layer[l], h_zphi_density_vs_layer[l]]
 
+# Per-cell histograms (e.g. per module in semiconductor detectors)
+h_avg_hits_x_layer_per_cell = {}
+bin_start = 0
+for l in layer_cells.keys():
+    cell_binning = [layer_cells[l], -0.5 + bin_start, layer_cells[l]-0.5  + bin_start]
+    h_avg_hits_x_layer_per_cell[l] = ROOT.TH1D(f"h_avg_hits_x_layer{l}_per_cell_{collection}", f"h_avg_hits_x_layer{l}_per_cell_{collection};Module ID;Hits / event", *cell_binning)
+    histograms += [h_avg_hits_x_layer_per_cell[l]]
+    if(sub_detector=="VertexBarrel" or sub_detector=="SiWrB"):
+        bin_start += layer_cells[l]
+    # if(l==2):
+    #     bin_start = bin_start*4  # don't understand yet why this is needed here
+
 # Pile-up histograms
 histograms += [
     h_tot_pu := ROOT.TH1D(f"h_tot_pu_{collection}", f"h_tot_pu_{collection}", integration_time+1, -0.5, integration_time+0.5),
     h_avg_pu_x_layer := ROOT.TH1D(f"h_avg_pu_x_layer_{collection}", f"h_avg_pu_x_layer_{collection}", *layer_binning)
 ]
+
+# Helper histograms
+histograms += [
+    hist_det_element_size := ROOT.TH1D("hist_det_element_size_"+collection, "hist_det_element_size_"+collection+";Layer;Size of sensor [mm^{2}];", *layer_binning), # Get the size of a cell (i.e. the size of the sensitive surface for semiconductor sensors)
+    hist_det_element_pixel_size_u := ROOT.TH1D("hist_det_element_pixel_size_u_"+collection, "hist_det_element_pixel_size_u"+collection+";Layer;Pixel size in u direction [mm];", *layer_binning), # Get the size of a single channel in u direction (i.e. the pixel size for semiconductor sensors)
+    hist_det_element_pixel_size_v := ROOT.TH1D("hist_det_element_pixel_size_v_"+collection, "hist_det_element_pixel_size_v"+collection+";Layer;Pixel size in u direction [mm];", *layer_binning), # Get the size of a single channel in u direction (i.e. the pixel size for semiconductor sensors)
+    hist_layer_cells := ROOT.TH1D("hist_layer_cells_"+collection, "hist_layer_cells_"+collection+";Layer;Number of cells;", *layer_binning) 
+]
+
+for det_element, cells in detector_dict["det_element_size"].items():
+    ln = layer_number_from_string(det_element)
+    hist_det_element_size.SetBinContent(ln+1, cells) # 0th bin is underflow
+for det_element, cells in detector_dict["det_element_pixel_size_u"].items():
+    ln = layer_number_from_string(det_element)
+    hist_det_element_pixel_size_u.SetBinContent(ln+1, cells) # 0th bin is underflow
+for det_element, cells in detector_dict["det_element_pixel_size_v"].items():
+    ln = layer_number_from_string(det_element)
+    hist_det_element_pixel_size_v.SetBinContent(ln+1, cells) # 0th bin is underflow
+for layer_cell in layer_cells.items():
+    hist_layer_cells.SetBinContent(layer_cell[0]+1, layer_cell[1]) # 0th bin is underflow
+histograms += [hist_det_element_size, hist_det_element_pixel_size_u, hist_det_element_pixel_size_v, hist_layer_cells]
+
 
 h_pu_x_layer = {}
 for l in layer_cells.keys():
@@ -371,6 +442,8 @@ for i,event in enumerate(podio_reader.get(tree_name)):
 
         #TODO: Handle better cell_id info
         layer_n = get_layer(cell_id, decoder, sub_detector, detector_type)
+        module_n = get_module(cell_id, decoder, sub_detector, detector_type)
+        sensor_n = get_sensor(cell_id, decoder, sub_detector, detector_type)
 
         E_hit_thr = 0
         if isinstance(E_thr_MeV, dict):
@@ -424,6 +497,7 @@ for i,event in enumerate(podio_reader.get(tree_name)):
             if not cell_fired:
                 h_avg_firing_cells_x_layer.Fill(layer_n, fill_weight)
 
+            h_avg_hits_x_layer_per_cell[layer_n].Fill(module_n, fill_weight)
             hist_zr.Fill(z_mm, r_mm, fill_weight)
             hist_xy.Fill(x_mm, y_mm, fill_weight)
             hist_zphi.Fill(z_mm, phi, fill_weight)
@@ -473,12 +547,8 @@ for i,event in enumerate(podio_reader.get(tree_name)):
 
     for l, fc in fired_cells_x_layer.items():
         tot_occupancy += fc
-        #print(f" fc:{fc}, l:{l},  nc:{layer_cells[l]} ")
-
         if layer_cells:
             layer_occupancy = fc / layer_cells[l] * 100
-            #print(f" fc:{fc}, nc:{layer_cells[l]}  , occ:{layer_occupancy}")
-
             h_avg_occ_x_layer.Fill(l, layer_occupancy * fill_weight)
             h_occ_x_layer[l].Fill(layer_occupancy, fill_weight)
 
@@ -501,6 +571,16 @@ for i,event in enumerate(podio_reader.get(tree_name)):
 
     processed_events +=1
 # <--- end of the event loop
+
+# Use all fired cells for semiconductor sensors, as quite often there are multiple hits per cellID, with each cellID describing one O(cm^2) large sensor.   
+# This will not be needed anymore once pixel/strip segmentation is added to these detectors in the DD4hep description. Then each pixel has its own cellID.
+
+
+if sub_detector == "VertexBarrel" or sub_detector == "VertexDisks" or sub_detector == "SiWrB" or sub_detector == "SiWrD":
+    h_avg_occ_x_layer_semicond = h_avg_hits_x_layer.Clone()
+    h_avg_occ_x_layer_semicond.Divide(hist_det_element_size*hist_layer_cells/hist_det_element_pixel_size_u/hist_det_element_pixel_size_v)
+    h_avg_occ_x_layer_semicond.SetNameTitle("h_avg_occ_x_layer_semicond"+collection, "h_avg_occ_x_layer_semicond"+collection)
+    histograms += [h_avg_occ_x_layer_semicond]
 
 print("Loop done!")
 print(" - Processed events:", processed_events)
@@ -533,7 +613,9 @@ if draw_hists:
     draw_hist(h_hit_t_corr, "Timing - TOF [ns]", "Hits / events",  sample_name+"_hit_t_corr_"+str(n_events)+"evt_"+sub_detector, collection)
     draw_hist(h_avg_hits_x_layer, "Layer number", "Hits / events",  sample_name+"_avg_hits_x_layer_"+str(n_events)+"evt_"+sub_detector, collection)
     draw_hist(h_avg_firing_cells_x_layer, "Layer number", "Firing cells / events",  sample_name+"_avg_firing_cells_x_layer_"+str(n_events)+"evt_"+sub_detector, collection)
-    draw_hist(h_avg_occ_x_layer, "Layer number", "Average occupancy [%]",  sample_name+"_avg_occ_x_layer_"+str(n_events)+"evt_"+sub_detector, collection, log_y=False)
+    if sub_detector == "VertexBarrel" or sub_detector == "VertexDisks" or sub_detector == "SiWrB" or sub_detector == "SiWrD":
+        draw_hist(h_avg_occ_x_layer_semicond, "Layer number", "Average pixel occupancy",  sample_name+"_avg_occ_x_layer_"+str(n_events)+"evt_"+sub_detector, collection, log_y=False)
+
     draw_hist(h_occ, "Occupancy [%]", "Entries / events",  sample_name+f"_occ_tot_"+str(n_events)+"evt_"+sub_detector, collection, log_x=True)
 
     if energy_per_layer:

--- a/plotting/hits2bw.py
+++ b/plotting/hits2bw.py
@@ -173,13 +173,16 @@ for ln, cells in detector_dict["det_element_cells"].items():
         counts = h_hitRate_per_cell[ln].GetBinContent(b)
         error = h_hitRate_per_cell[ln].GetBinError(b)
 
-        if(sub_detector=="VertexDisks" and layer_n==0):
+        if((sub_detector=="VertexDisks" and layer_n==0) or (sub_detector=="SiWrD" and layer_n==0)):
             continue
             
         # convert hits / occupancy to MHz / cm^2
         scale_factor = 1
-        scale_factor *= rate * cm2_to_mm2 / det_element_size[str(int(abs(ln)))]
-
+        try:
+            scale_factor *= rate * cm2_to_mm2 / det_element_size[str(int(abs(ln)))]
+        except KeyError:
+            print("Skipping this layer!")
+            
         # Consider additional modifiers
         for m in multipliers.values():
             scale_factor *= m

--- a/plotting/hits2highLevelEstimations.py
+++ b/plotting/hits2highLevelEstimations.py
@@ -132,7 +132,6 @@ hist_pixel_size_v = ROOT.TH1D("hist_pixel_size_v", "Pixel Size V per Layer;Layer
 
 # Fill the histograms with data
 for layer, value in n_cells.items():
-    print(int(layer+1+(len(n_cells)/2 if is_endcap(detector_type) else 0)), value)
     hist_n_cells.SetBinContent(int(layer+1+(len(n_cells)/2 if is_endcap(detector_type) else 0)), value)
 
 for layer, value in sensor_size_map.items():

--- a/plotting/hits2highLevelEstimations.py
+++ b/plotting/hits2highLevelEstimations.py
@@ -32,7 +32,10 @@ parser.add_argument('-a', '--assumptions',
 parser.add_argument('-r', '--rate',
                   type=float, default=52.,
                   help='hit rate in MHz.')
-
+parser.add_argument('--hitRateOccPlots',
+                  action="store_true",
+                  help='Create hit rate and pixel occupancy plots (needs pixel size assumption and sensor sizes).')
+                  
 options = parser.parse_args()
 
 input_file_path = options.inputFile
@@ -40,6 +43,7 @@ output_file_name = options.outputFile
 detector_dict_path = options.detDictFile
 assumptions_path = options.assumptions
 rate = options.rate
+do_hitRateOcc_plots = options.hitRateOccPlots
 
 ######################################
 # style
@@ -74,15 +78,41 @@ strategy = assumptions_dict["strategy"]
 hit_size = assumptions_dict["hit_size"]
 multipliers = assumptions_dict["multipliers"]
 
-pixel_size_uv = simplify_dict(assumptions_dict["pixel_size_uv"])
-print(f"Pixel size uv: {pixel_size_uv}")
-
 # Update layer related dictionary to have identical keys
-n_cells = simplify_dict(detector_dict["det_element_cells"])
-print("Number of cells: ",n_cells)
-sensor_size_map = simplify_dict(detector_dict["sensor_size_map"])
-sensors_per_module_map = simplify_dict(detector_dict["sensors_per_module_map"])
-print(f"Sensor size: {sensor_size_map}, sensors per module: {sensors_per_module_map}")
+layer_cells = simplify_dict(detector_dict["det_element_cells"])
+print("Number of cells: ",layer_cells)
+n_layers = len(layer_cells.keys())
+layer_binning = [n_layers + 1, -0.5, n_layers + 0.5]
+if is_endcap(detector_type):
+    print("Endcap detector detected, adjusting layer binning accordingly")
+    max_l = int(n_layers / 2) + 0.5
+    layer_binning = [n_layers + 1, -max_l, +max_l]
+
+# Get and fill histogram data related to module and pixel sizes
+if do_hitRateOcc_plots:
+    pixel_size_uv = simplify_dict(assumptions_dict["pixel_size_uv"])
+    hist_pixel_area = ROOT.TH1D("hist_pixel_area", "Pixel area per Layer;Layer;Pixel area [mm^{2}]", *layer_binning)
+    for layer, value in pixel_size_uv.items():
+        hist_pixel_area.Fill(layer, value[0]*value[1])
+    hist_pixel_area.Sumw2(False)
+
+    hist_sensor_size = ROOT.TH1D("hist_sensor_size", "Sensor size per Layer;Layer;Sensor size [mm^{2}]", *layer_binning)
+    sensor_size_map = simplify_dict(detector_dict["sensor_size_map"])
+    for layer, value in sensor_size_map.items():
+        hist_sensor_size.Fill(layer, value)
+    hist_sensor_size.Sumw2(False)
+
+    hist_sensors_per_module = ROOT.TH1D("hist_sensors_per_module", "Sensors per module;Layer;Sensors per module", *layer_binning)
+    sensors_per_module_map = simplify_dict(detector_dict["sensors_per_module_map"])
+    for layer, value in sensors_per_module_map.items():
+        hist_sensors_per_module.Fill(layer, value)
+    hist_sensors_per_module.Sumw2(False)
+
+    hist_module_size = hist_sensor_size.Clone()
+    hist_module_size.Multiply(hist_sensors_per_module)
+    hist_module_size.SetNameTitle("hist_module_size", "Module size per Layer;Layer;Module size [mm^{2}]")
+
+    print(f"Sensor size: {sensor_size_map}, sensors per module: {sensors_per_module_map}, module size: {[hist_module_size.GetBinContent(i+1) for i in range(hist_module_size.GetNbinsX())]}")
 
 if isinstance(hit_size, dict):
     hit_size_tmp = simplify_dict(hit_size)
@@ -112,42 +142,13 @@ h_avg_occ_cell_per_layer = input_file.Get(h_name).Clone()
 h_max_cell_occ = input_file.Get(h_name).Clone() 
 h_max_cell_occ.Reset()
 
-layer_cells = {}
-for ln, cells in detector_dict["det_element_cells"].items():
-    layer_cells[ln] = cells
-
-n_layers = len(layer_cells.keys())
-layer_binning = [n_layers, -0.5, n_layers - 0.5]
-if is_endcap(detector_type):
-    print("Endcap detector detected, adjusting layer binning accordingly")
-    max_l = int(n_layers / 2) + 0.5
-    layer_binning = [n_layers + 1, -max_l, +max_l]
-
 
 hist_n_cells = ROOT.TH1D("hist_n_cells", "Number of Cells per Layer;Layer;Number of Cells", *layer_binning) # This is the number of sensors in case of semiconductor detectors
-hist_sensor_size = ROOT.TH1D("hist_sensor_size", "Sensor size per Layer;Layer;Sensor size [mm^{2}]", *layer_binning)
-hist_sensors_per_module = ROOT.TH1D("hist_sensors_per_module", "Sensors per module;Layer;Sensors per module", *layer_binning)
-hist_pixel_size_u = ROOT.TH1D("hist_pixel_size_u", "Pixel Size U per Layer;Layer;Pixel Size U [mm]", *layer_binning)
-hist_pixel_size_v = ROOT.TH1D("hist_pixel_size_v", "Pixel Size V per Layer;Layer;Pixel Size V [mm]", *layer_binning)
 
 # Fill the histograms with data
-for layer, value in n_cells.items():
-    hist_n_cells.SetBinContent(int(layer+1+(len(n_cells)/2 if is_endcap(detector_type) else 0)), value)
-
-for layer, value in sensor_size_map.items():
-    hist_sensor_size.SetBinContent(int(layer+1+(len(n_cells)/2 if is_endcap(detector_type) else 0)), value)
-
-for layer, value in sensors_per_module_map.items():
-    hist_sensors_per_module.SetBinContent(int(layer+1+(len(n_cells)/2 if is_endcap(detector_type) else 0)), value)
-
-# Currently not used but kept for future use
-hist_module_size = hist_sensor_size.Clone()
-hist_module_size.Multiply(hist_sensors_per_module)
-hist_module_size.SetNameTitle("hist_module_size", "Module size per Layer;Layer;Module size [mm^{2}]")
-
-for layer, value in pixel_size_uv.items():
-    hist_pixel_size_u.SetBinContent(int(layer+1+(len(n_cells)/2 if is_endcap(detector_type) else 0)), value[0])
-    hist_pixel_size_v.SetBinContent(int(layer+1+(len(n_cells)/2 if is_endcap(detector_type) else 0)), value[1])
+for layer, value in layer_cells.items():
+    hist_n_cells.Fill(layer, value)
+hist_n_cells.Sumw2(False)
 
 #######################################
 # convert the counts/occupancy histogram to estimate of high-level properties (bandwidth, hit rate, etc.)
@@ -166,7 +167,11 @@ for b in range(1, h_bw.GetNbinsX()+1):
         scale_factor *= rate * MHz_to_Hz * hit_size[layer_n] * b_to_GB
 
     if strategy == "occupancy":
-        scale_factor *= cells[layer_n] * 0.01
+        try:
+            scale_factor *= layer_cells[layer_n] * 0.01
+        except KeyError:
+            print(f"Layer {layer_n} not found in layer_cells dictionary. Setting number of cells to 1 for this layer")
+            scale_factor *= 1.0 * 0.01
 
     # Consider additional modifiers
     for m in multipliers.values():
@@ -179,54 +184,53 @@ scale_factor = 1
 for m in multipliers.values():
     scale_factor *= m
 
-# Average hit rate per layer
-h_avg_hit_rate.Scale(rate*cm2_to_mm2*scale_factor)
-h_avg_hit_rate.Divide(hist_n_cells*hist_sensor_size)
-h_avg_hit_rate.SetNameTitle(f"{input_file_name}_avg_hit_rate_per_layer", f"{input_file_name}_avg_hit_rate_per_layer")
-draw_hist(h_avg_hit_rate, "Layer", "Average hit rate [MHz/cm^{2}]", f"{input_file_name}_hit_rate_per_layer")
+if do_hitRateOcc_plots:
+    # Average hit rate per layer
+    h_avg_hit_rate.Scale(rate*cm2_to_mm2*scale_factor)
+    h_avg_hit_rate.Divide(hist_n_cells*hist_sensor_size)
+    h_avg_hit_rate.SetNameTitle(f"{input_file_name}_avg_hit_rate_per_layer", f"{input_file_name}_avg_hit_rate_per_layer")
+    draw_hist(h_avg_hit_rate, "Layer", "Average hit rate [MHz/cm^{2}]", f"{input_file_name}_hit_rate_per_layer")
 
-# Average cell occupancy per layer
-h_avg_occ_cell_per_layer.Scale(scale_factor)
-h_avg_occ_cell_per_layer.Divide(hist_n_cells*hist_sensor_size/hist_pixel_size_u/hist_pixel_size_v)
-h_avg_occ_cell_per_layer.SetNameTitle(f"{input_file_name}_avg_occ_per_layer", f"{input_file_name}_avg_occ_per_layer;Layer;Average pixel occupancy per event")
-draw_hist(h_avg_occ_cell_per_layer, "Layer", "Average pixel occupancy per event", f"{input_file_name}_avg_pixel_occupancy_per_layer")
+    # Average cell occupancy per layer
+    h_avg_occ_cell_per_layer.Scale(scale_factor)
+    h_avg_occ_cell_per_layer.Divide(hist_n_cells*hist_sensor_size/hist_pixel_area)
+    h_avg_occ_cell_per_layer.SetNameTitle(f"{input_file_name}_avg_occ_per_layer", f"{input_file_name}_avg_occ_per_layer;Layer;Average pixel occupancy per event")
+    draw_hist(h_avg_occ_cell_per_layer, "Layer", "Average pixel occupancy per event", f"{input_file_name}_avg_pixel_occupancy_per_layer")
 
+    h_avg_hit_rate_per_cell = {}
+    h_occ_per_cell = {}
 
+    for i, (ln, cells) in enumerate(detector_dict["det_element_cells"].items()):
+        if is_endcap(detector_type):
+            i_layer_bin = int(ln + len(detector_dict["det_element_cells"])/2) + 1 # to skip layer 0 in case of disk
+        else:
+            i_layer_bin = ln + 1
 
-h_avg_hit_rate_per_cell = {}
-h_occ_per_cell = {}
+        # Hit rate per module
+        h_avg_hit_rate_per_cell[ln] = input_file.Get(f"h_avg_hits_x_layer{ln}_x_module_{hits_collection}").Clone()
+        h_avg_hit_rate_per_cell[ln].Scale(rate*cm2_to_mm2*scale_factor/hist_module_size.GetBinContent(i_layer_bin))
+        h_avg_hit_rate_per_cell[ln].SetNameTitle(f"{input_file_name}_hitRate_layer{ln}_per_cell", f"{input_file_name}_hitRate_layer{ln}_per_cell;Module;Average hit rate per module [MHz/cm^{2}]" )
+        draw_hist(h_avg_hit_rate_per_cell[ln], "Module", "Average hit rate [MHz/cm^{2}]", f"{input_file_name}_hitRate_layer{ln}_per_cell", )
 
-for i, (ln, cells) in enumerate(detector_dict["det_element_cells"].items()):
-    if is_endcap(detector_type):
-        i_layer_bin = int(ln + len(detector_dict["det_element_cells"])/2) + 1 # to skip layer 0 in case of disk
-    else:
-        i_layer_bin = ln + 1
+        # Extract maximal hit rate per module
+        h_max_hit_rate.SetBinContent(i_layer_bin, h_avg_hit_rate_per_cell[ln].GetMaximum())
+        h_max_hit_rate.SetBinError(i_layer_bin, h_avg_hit_rate_per_cell[ln].GetBinError(h_avg_hit_rate_per_cell[ln].GetMaximumBin()))
 
-    # Hit rate per cell (i.e. module in semiconductor detectors)
-    h_avg_hit_rate_per_cell[ln] = input_file.Get(f"h_avg_hits_x_layer{ln}_per_cell_{hits_collection}").Clone()
-    h_avg_hit_rate_per_cell[ln].Scale(rate*cm2_to_mm2*scale_factor/hist_module_size.GetBinContent(i_layer_bin))
-    h_avg_hit_rate_per_cell[ln].SetNameTitle(f"{input_file_name}_hitRate_layer{ln}_per_cell", f"{input_file_name}_hitRate_layer{ln}_per_cell;Module;Average hit rate per module [MHz/cm^{2}]" )
-    draw_hist(h_avg_hit_rate_per_cell[ln], "Module", "Average hit rate [MHz/cm^{2}]", f"{input_file_name}_hitRate_layer{ln}_per_cell", )
+        # Occupancy per module (i.e. pixel occupancy in semiconductor detector). This will not be needed anymore once pixel/strip segmentation is added to these detectors in the DD4hep description. Then each pixel has its own cellID.
+        h_occ_per_cell[ln] = input_file.Get(f"h_avg_hits_x_layer{ln}_x_module_{hits_collection}").Clone()
+        h_occ_per_cell[ln].Scale(scale_factor/(hist_module_size.GetBinContent(i_layer_bin)/hist_pixel_area.GetBinContent(i_layer_bin)))
+        h_occ_per_cell[ln].SetNameTitle(f"{input_file_name}_occ_x_module_layer{ln}", f"{input_file_name}_occ_x_module_layer{ln};Module;Pixel occupancy per event" )
+        draw_hist(h_occ_per_cell[ln], "Module", "Pixel occupancy per event", f"{input_file_name}_occ_x_module_layer{ln}")
 
-    # Extract maximal hit rate per cell
-    h_max_hit_rate.SetBinContent(i_layer_bin, h_avg_hit_rate_per_cell[ln].GetMaximum())
-    h_max_hit_rate.SetBinError(i_layer_bin, h_avg_hit_rate_per_cell[ln].GetBinError(h_avg_hit_rate_per_cell[ln].GetMaximumBin()))
+        # Extract maximal occupancy per module
+        h_max_cell_occ.SetBinContent(i_layer_bin, h_occ_per_cell[ln].GetMaximum())
+        h_max_cell_occ.SetBinError(i_layer_bin, h_occ_per_cell[ln].GetBinError(h_occ_per_cell[ln].GetMaximumBin()))
 
-    # Occupancy per cell (i.e. pixel occupancy in semiconductor detector)
-    h_occ_per_cell[ln] = input_file.Get(f"h_avg_hits_x_layer{ln}_per_cell_{hits_collection}").Clone()
-    h_occ_per_cell[ln].Scale(scale_factor/(hist_module_size.GetBinContent(i_layer_bin)/hist_pixel_size_u.GetBinContent(i_layer_bin)/hist_pixel_size_v.GetBinContent(i_layer_bin)))
-    h_occ_per_cell[ln].SetNameTitle(f"{input_file_name}_occ_per_cell_layer{ln}", f"{input_file_name}_occ_per_cell_layer{ln};Module;Pixel occupancy per event" )
-    draw_hist(h_occ_per_cell[ln], "Module", "Pixel occupancy per event", f"{input_file_name}_occ_per_cell_layer{ln}")
+    h_max_hit_rate.SetNameTitle(f"{input_file_name}_max_hit_rate_per_cell", f"{input_file_name}_max_hit_rate_per_cell;Layer;Maximal hit rate per module [MHz/cm^{2}]")
+    draw_hist(h_max_hit_rate, "Layer", "Maximal hit rate [MHz/cm^{2}]", f"{input_file_name}_max_hit_rate_per_layer")
 
-    # Extract maximal occupancy per cell
-    h_max_cell_occ.SetBinContent(i_layer_bin, h_occ_per_cell[ln].GetMaximum())
-    h_max_cell_occ.SetBinError(i_layer_bin, h_occ_per_cell[ln].GetBinError(h_occ_per_cell[ln].GetMaximumBin()))
-
-h_max_hit_rate.SetNameTitle(f"{input_file_name}_max_hit_rate_per_cell", f"{input_file_name}_max_hit_rate_per_cell;Layer;Maximal hit rate per module [MHz/cm^{2}]")
-draw_hist(h_max_hit_rate, "Layer", "Maximal hit rate [MHz/cm^{2}]", f"{input_file_name}_max_hit_rate_per_layer")
-
-h_max_cell_occ.SetNameTitle(f"{input_file_name}_max_cell_occupancy", f"{input_file_name}_max_cell_occupancy;Layer;Maximal pixel occupancy per event")
-draw_hist(h_max_cell_occ, "Layer", "Maximal pixel occupancy per event", f"{input_file_name}_max_pixel_occupancy_per_layer")
+    h_max_cell_occ.SetNameTitle(f"{input_file_name}_max_cell_occupancy", f"{input_file_name}_max_cell_occupancy;Layer;Maximal pixel occupancy per event")
+    draw_hist(h_max_cell_occ, "Layer", "Maximal pixel occupancy per event", f"{input_file_name}_max_pixel_occupancy_per_layer")
 
 #######################################
 # Output the results
@@ -242,17 +246,17 @@ draw_hist(h_bw, "Layer", "Bandwidth [GB/s]", f"{input_file_name}_bw_per_layer", 
 output_file_name = f"{input_file_name}_{output_file_name}.root"
 with ROOT.TFile(output_file_name,"RECREATE") as f:
     h_bw.Write()
-    h_avg_hit_rate.Write()
-    h_max_hit_rate.Write()
-    h_avg_occ_cell_per_layer.Write()
-    h_max_cell_occ.Write()
     hist_n_cells.Write()
-    hist_sensor_size.Write()
-    hist_sensors_per_module.Write()
-    hist_module_size.Write()
-    hist_pixel_size_u.Write()
-    hist_pixel_size_v.Write()
-    for ln, cells in detector_dict["det_element_cells"].items():
-        h_avg_hit_rate_per_cell[ln].Write()
-        h_occ_per_cell[ln].Write()
+    if do_hitRateOcc_plots:
+        h_avg_hit_rate.Write()
+        h_max_hit_rate.Write()
+        h_avg_occ_cell_per_layer.Write()
+        h_max_cell_occ.Write()
+        hist_sensor_size.Write()
+        hist_sensors_per_module.Write()
+        hist_module_size.Write()
+        hist_pixel_area.Write()
+        for ln, cells in detector_dict["det_element_cells"].items():
+            h_avg_hit_rate_per_cell[ln].Write()
+            h_occ_per_cell[ln].Write()
 print("Histograms saved in:", output_file_name)

--- a/plotting/hits2highLevelEstimations.py
+++ b/plotting/hits2highLevelEstimations.py
@@ -74,9 +74,8 @@ strategy = assumptions_dict["strategy"]
 hit_size = assumptions_dict["hit_size"]
 multipliers = assumptions_dict["multipliers"]
 
-pixel_size_u = simplify_dict(assumptions_dict["pixel_size_u"])
-pixel_size_v = simplify_dict(assumptions_dict["pixel_size_v"])
-print(f"Pixel size u: {pixel_size_u}, pixel size v: {pixel_size_v}")
+pixel_size_uv = simplify_dict(assumptions_dict["pixel_size_uv"])
+print(f"Pixel size uv: {pixel_size_uv}")
 
 # Update layer related dictionary to have identical keys
 n_cells = simplify_dict(detector_dict["det_element_cells"])
@@ -147,12 +146,9 @@ hist_module_size = hist_sensor_size.Clone()
 hist_module_size.Multiply(hist_sensors_per_module)
 hist_module_size.SetNameTitle("hist_module_size", "Module size per Layer;Layer;Module size [mm^{2}]")
 
-for layer, value in pixel_size_u.items():
-    hist_pixel_size_u.SetBinContent(int(layer+1+(len(n_cells)/2 if is_endcap(detector_type) else 0)), value)
-
-for layer, value in pixel_size_v.items():
-    hist_pixel_size_v.SetBinContent(int(layer+1+(len(n_cells)/2 if is_endcap(detector_type) else 0)), value)
-
+for layer, value in pixel_size_uv.items():
+    hist_pixel_size_u.SetBinContent(int(layer+1+(len(n_cells)/2 if is_endcap(detector_type) else 0)), value[0])
+    hist_pixel_size_v.SetBinContent(int(layer+1+(len(n_cells)/2 if is_endcap(detector_type) else 0)), value[1])
 
 #######################################
 # convert the counts/occupancy histogram to estimate of high-level properties (bandwidth, hit rate, etc.)

--- a/plotting/hits2highLevelEstimations.py
+++ b/plotting/hits2highLevelEstimations.py
@@ -14,8 +14,8 @@ from visualization import setup_root_style, draw_hist
 ######################################
 # option parser
 
-parser = argparse.ArgumentParser(description='hits2bw.py',
-        epilog='Example:\nhits2bw.py -i <path_to_hits_histograms.root> -d $BIB_STUDIES/detectors_dicts/ALLEGRO_o1_v03_DetectorDimensions.json -a $BIB_STUDIES/detectors_dicts/ALLEGRO_o1_v03_assumptions.json',
+parser = argparse.ArgumentParser(description='hits2highLevelEstimations.py',
+        epilog='Example:\nhits2highLevelEstimations.py -i <path_to_hits_histograms.root> -d $BIB_STUDIES/detectors_dicts/ALLEGRO_o1_v03_DetectorDimensions.json -a $BIB_STUDIES/detectors_dicts/ALLEGRO_o1_v03_assumptions.json',
         formatter_class=argparse.ArgumentDefaultsHelpFormatter)
 parser.add_argument('-i', '--inputFile',
                   type=str, default='',

--- a/plotting/xml2json.py
+++ b/plotting/xml2json.py
@@ -68,8 +68,10 @@ for subdet_name, sens_det in det.sensitiveDetectors():
     hitsCollection = str(sens_det.hitsCollection)
     print("        hits = ", hitsCollection)
 
-    det_element_cells = get_cells_map(det, subdet, subdet_name)
+    det_element_cells, sensor_size_map, sensors_per_module_map = get_cells_map(det, subdet, subdet_name)
     print("        det_element_cells = ", det_element_cells)
+    print("        sensor_size_map = ", sensor_size_map)
+    print("        sensors_per_module_map = ", sensors_per_module_map)
 
     # Get max dimensions for the subdetector in x,y,z (half-length form 0)
     volume = subdet.volume()
@@ -88,6 +90,8 @@ for subdet_name, sens_det in det.sensitiveDetectors():
             'typeFlag': subdet.typeFlag(),
             'hitsCollection': hitsCollection,
             'det_element_cells': det_element_cells,
+            'sensor_size_map': sensor_size_map,
+            'sensors_per_module_map': sensors_per_module_map,
             'max_z': max_z, 
             'max_r': max_r,
         }

--- a/python/ALLEGRO.py
+++ b/python/ALLEGRO.py
@@ -22,6 +22,9 @@ def get_cells_map(detector, sub_det, name, skip_pattern = r"(supportTube)|(cryo)
     re_skip = re.compile(skip_pattern)
 
     cells_map = defaultdict(int)
+    sensor_size_map = defaultdict(float)
+    sensors_per_module_map = defaultdict(int)
+
 
     # N.B. this could be affected from naming scheme changes,
     # will need to keep track also of the geo versions.
@@ -116,13 +119,41 @@ def get_cells_map(detector, sub_det, name, skip_pattern = r"(supportTube)|(cryo)
                 if i==0: continue
                 cells_map[f"layer{i}"] = total_cells
 
-        case "VertexDisks":
+        case "VertexBarrel" | "SiWrB":
             # Rename layers shifting their value by 1
             # to remove degeneracy of layer 0
             # N.B. this needs to be accounted when reading the layer number
 
             for de_name, de in sub_det.children():
-                cells_map[str(de_name)] = get_cells(de)
+                modules = 0
+                sensors = 0
+                for de_name2, de2 in de.children():
+                    modules += 1
+                    for de_name3, de3 in de2.children():
+                        sensors += 1
+                        area = de3.volume().solid().GetDY()*2.*10.*de3.volume().solid().GetDZ()*2.*10. # Make it to mm and get sensor area in mm2. Assuming each sensor has the same area!
+                        # print("   sensor area (mm2): ", area)
+                cells_map[str(de_name)] = sensors
+                sensor_size_map[str(de_name)] = area
+                sensors_per_module_map[str(de_name)] = sensors / modules
+
+        case "VertexDisks" | "SiWrD":
+            # Rename layers shifting their value by 1
+            # to remove degeneracy of layer 0
+            # N.B. this needs to be accounted when reading the layer number
+
+            for de_name, de in sub_det.children():
+                modules = 0
+                sensors = 0
+                for de_name2, de2 in de.children():
+                    modules += 1
+                    for de_name3, de3 in de2.children():
+                        sensors += 1
+                        area = de3.volume().solid().GetDX()*2.*10.*de3.volume().solid().GetDY()*2.*10. # Make it to mm and get sensor area in mm2. Assuming each sensor has the same area!
+                        # print("   sensor area (mm2): ", area)
+                cells_map[str(de_name)] = sensors
+                sensor_size_map[str(de_name)] = area
+                sensors_per_module_map[str(de_name)] = sensors / modules
 
             old_keys = list(cells_map.keys())
             for k in old_keys:
@@ -132,17 +163,8 @@ def get_cells_map(detector, sub_det, name, skip_pattern = r"(supportTube)|(cryo)
                     ln *= -1
                 new_key = f"layer{ln}"
                 cells_map[new_key] = cells_map.pop(k)
-
-        case "SiWrD":
-            #loop from -2 to 2, skipping 0, to set the layers indices for the endcaps
-            for i in range(-2,3):
-                if i==0: continue
-                cells_map[f"layer{i}"] = 7500  #hardcoding channels per layer for now
-
-        case "SiWrB":
-            # loop from 0 to 1 to set the layers indices for the barrel
-            for i in range(2):
-                cells_map[f"layer{i}"] = 20_000  #hardcoding channels per layer for now, https://arxiv.org/abs/2502.21223v4
+                sensor_size_map[new_key] = sensor_size_map.pop(k)
+                sensors_per_module_map[new_key] = sensors_per_module_map.pop(k)
 
         case _:
             # Loop over detector elements
@@ -154,7 +176,7 @@ def get_cells_map(detector, sub_det, name, skip_pattern = r"(supportTube)|(cryo)
                         continue
                 cells_map[str(de_name)] = get_cells(de)
 
-    return cells_map
+    return cells_map, sensor_size_map, sensors_per_module_map
 
 
 def get_layer(cell_id, decoder, detector, dtype):

--- a/python/ALLEGRO.py
+++ b/python/ALLEGRO.py
@@ -218,3 +218,11 @@ def get_layer(cell_id, decoder, detector, dtype):
 
             return layer
     return
+
+def get_module(cell_id, decoder, detector, dtype):
+    module = decoder.get(cell_id, "module")
+    return module
+
+def get_sensor(cell_id, decoder, detector, dtype):
+    sensor = decoder.get(cell_id, "sensor")
+    return sensor    

--- a/python/ALLEGRO.py
+++ b/python/ALLEGRO.py
@@ -135,7 +135,7 @@ def get_cells_map(detector, sub_det, name, skip_pattern = r"(supportTube)|(cryo)
                         # print("   sensor area (mm2): ", area)
                 cells_map[str(de_name)] = sensors
                 sensor_size_map[str(de_name)] = area
-                sensors_per_module_map[str(de_name)] = sensors / modules
+                sensors_per_module_map[str(de_name)] = int(sensors / modules)
 
         case "VertexDisks" | "SiWrD":
             # Rename layers shifting their value by 1
@@ -153,7 +153,7 @@ def get_cells_map(detector, sub_det, name, skip_pattern = r"(supportTube)|(cryo)
                         # print("   sensor area (mm2): ", area)
                 cells_map[str(de_name)] = sensors
                 sensor_size_map[str(de_name)] = area
-                sensors_per_module_map[str(de_name)] = sensors / modules
+                sensors_per_module_map[str(de_name)] = int(sensors / modules)
 
             old_keys = list(cells_map.keys())
             for k in old_keys:
@@ -242,7 +242,10 @@ def get_layer(cell_id, decoder, detector, dtype):
     return
 
 def get_module(cell_id, decoder, detector, dtype):
-    module = decoder.get(cell_id, "module")
+    try:
+        module = decoder.get(cell_id, "module")
+    except:
+        module = 0 # For systems that don't have modules
     return module
 
 def get_sensor(cell_id, decoder, detector, dtype):

--- a/python/IDEA.py
+++ b/python/IDEA.py
@@ -21,18 +21,49 @@ def get_cells_map(detector, sub_det, name, skip_pattern = r"(supportTube)|(cryo)
     re_skip = re.compile(skip_pattern)
 
     cells_map = defaultdict(int)
+    sensor_size_map = defaultdict(float)
+    sensors_per_module_map = defaultdict(int)
+
 
     # N.B. this could be affected from naming scheme changes,
     # will need to keep track also of the geo versions.
     match name:
 
-        case "VertexDisks":
+        case "VertexBarrel" | "SiWrB":
             # Rename layers shifting their value by 1
             # to remove degeneracy of layer 0
             # N.B. this needs to be accounted when reading the layer number
 
             for de_name, de in sub_det.children():
-                cells_map[str(de_name)] = get_cells(de)
+                modules = 0
+                sensors = 0
+                for de_name2, de2 in de.children():
+                    modules += 1
+                    for de_name3, de3 in de2.children():
+                        sensors += 1
+                        area = de3.volume().solid().GetDY()*2.*10.*de3.volume().solid().GetDZ()*2.*10. # Make it to mm and get sensor area in mm2. Assuming each sensor has the same area!
+                        # print("   sensor area (mm2): ", area)
+                cells_map[str(de_name)] = sensors
+                sensor_size_map[str(de_name)] = area
+                sensors_per_module_map[str(de_name)] = sensors / modules
+
+        case "VertexDisks" | "SiWrD":
+            # Rename layers shifting their value by 1
+            # to remove degeneracy of layer 0
+            # N.B. this needs to be accounted when reading the layer number
+
+            for de_name, de in sub_det.children():
+                modules = 0
+                sensors = 0
+                for de_name2, de2 in de.children():
+                    modules += 1
+                    for de_name3, de3 in de2.children():
+                        sensors += 1
+                        area = de3.volume().solid().GetDX()*2.*10.*de3.volume().solid().GetDY()*2.*10. # Make it to mm and get sensor area in mm2. Assuming each sensor has the same area!
+                        # print("   sensor area (mm2): ", area)
+                cells_map[str(de_name)] = sensors
+                sensor_size_map[str(de_name)] = area
+                sensors_per_module_map[str(de_name)] = sensors / modules
 
             old_keys = list(cells_map.keys())
             for k in old_keys:
@@ -42,17 +73,8 @@ def get_cells_map(detector, sub_det, name, skip_pattern = r"(supportTube)|(cryo)
                     ln *= -1
                 new_key = f"layer{ln}"
                 cells_map[new_key] = cells_map.pop(k)
-
-        case "SiWrD":
-            # loop from -2 to 2, skipping 0, to set the layers indices for the endcaps
-            for i in range(-2,3):
-                if i==0: continue
-                cells_map[f"layer{i}"] = 7500  #hardcoding channels per layer for now
-
-        case "SiWrB":
-            # loop from 0 to 1 to set the layers indices for the barrel
-            for i in range(2):
-                cells_map[f"layer{i}"] = 20_000  #hardcoding channels per layer for now, https://arxiv.org/abs/2502.21223v4
+                sensor_size_map[new_key] = sensor_size_map.pop(k)
+                sensors_per_module_map[new_key] = sensors_per_module_map.pop(k)
 
         case _:
             # Loop over detector elements
@@ -64,7 +86,7 @@ def get_cells_map(detector, sub_det, name, skip_pattern = r"(supportTube)|(cryo)
                         continue
                 cells_map[str(de_name)] = get_cells(de)
 
-    return cells_map
+    return cells_map, sensor_size_map, sensors_per_module_map
 
 
 def get_layer(cell_id, decoder, detector, dtype):

--- a/python/IDEA.py
+++ b/python/IDEA.py
@@ -45,7 +45,7 @@ def get_cells_map(detector, sub_det, name, skip_pattern = r"(supportTube)|(cryo)
                         # print("   sensor area (mm2): ", area)
                 cells_map[str(de_name)] = sensors
                 sensor_size_map[str(de_name)] = area
-                sensors_per_module_map[str(de_name)] = sensors / modules
+                sensors_per_module_map[str(de_name)] = int(sensors / modules)
 
         case "VertexDisks" | "SiWrD":
             # Rename layers shifting their value by 1
@@ -63,7 +63,7 @@ def get_cells_map(detector, sub_det, name, skip_pattern = r"(supportTube)|(cryo)
                         # print("   sensor area (mm2): ", area)
                 cells_map[str(de_name)] = sensors
                 sensor_size_map[str(de_name)] = area
-                sensors_per_module_map[str(de_name)] = sensors / modules
+                sensors_per_module_map[str(de_name)] = int(sensors / modules)
 
             old_keys = list(cells_map.keys())
             for k in old_keys:
@@ -123,3 +123,14 @@ def get_layer(cell_id, decoder, detector, dtype):
 
             return layer
     return
+
+def get_module(cell_id, decoder, detector, dtype):
+    try:
+        module = decoder.get(cell_id, "module")
+    except:
+        module = 0 # For systems that don't have modules
+    return module
+
+def get_sensor(cell_id, decoder, detector, dtype):
+    sensor = decoder.get(cell_id, "sensor")
+    return sensor    

--- a/python/constants.py
+++ b/python/constants.py
@@ -5,3 +5,4 @@
 C_MM_NS = 299.792   # speed of light in mm/ns
 b_to_GB = 1.25e-10  # bit to GB conversion factor
 MHz_to_Hz = 1e6    # MHz to Hz conversion factor
+cm2_to_mm2 = 1e2    # cm^2 to mm^2 conversion factor


### PR DESCRIPTION
Hi 

This MR implements various improvements to the background estimation for the vertex detector and silicon wrapper (or in general any semiconductor tracker). 
**ALLEGRO detector dimensions and assumptions**
- Fixed the number of cells in the silicon wrapper to be consistent with current silicon wrapper DD4hep description (just one sensitive element per stave, so 151 per layer)
- Fixed the number of cells in the vertex, so that one cell = one module. This could be changed to instead use individual sensors in the future.
- Added module (=cell) size for the vertex and silicon wrapper
- Added pixel sizes to estimate pixel occupancy (not taking into account dead time yet)
- Assuming 32 bits/hit for the vertex and 64 bits/hit for the silicon wrapper. This is more realistic given current sensor developments.

**drawhits.py**
- x-y and z-phi hit maps are now plotted per layer
- layer binning is fixed to be from 0 to nlayers-1 for barrels and -nlayers/2 to +nlayers+1 for endcaps

**plotting/hits2highLevelEstimations.py replacing plotting/hits2bw.py**
- Adding pixel occupancy and hit rate plots both per layer and also per cell (=per module), as well as maximal occupancy and hit rate per layer
- I left the bandwidth estimation as it was, but I think it's easier using TH1.Scale and TH1.Multiply/Divide than looping over the bins of the histograms. Happy to change that one as well if you prefer that.

See the set of plots this generates using the `2025-11-11` release and 3994 IPC collisions from `/eos/home-s/sfranche/FCC/samples/bib/ipc/aciarma_4IP_2024may29_Z/TDAQ-WS1_ALLEGRO_o1_v03_r2025-11-03.root` : [Plots](https://cernbox.cern.ch/s/rL2RX5HMPkQdrXZ).
