### PR TITLE
Add option for digitized hits in the hit2bw

### DIFF
--- a/detectors_dicts/ALLEGRO_o1_v03_assumptions.json
+++ b/detectors_dicts/ALLEGRO_o1_v03_assumptions.json
@@ -25,7 +25,7 @@
 
   "DCH_v2": {
     "strategy": "occupancy",
-    "hit_size": 2,
+    "hit_size": 4,
     "multipliers": {
       "n_samples": 400
     }
@@ -33,7 +33,7 @@
 
   "ECalBarrel": {
     "strategy": "hit_counts",
-    "hit_size": 2,
+    "hit_size": 160,
     "multipliers": {
       "n_samples": 1
     },
@@ -57,7 +57,7 @@
 
   "EMEC_turbine": {
     "strategy": "hit_counts",
-    "hit_size": 2,
+    "hit_size": 160,
     "multipliers": {
       "n_samples": 1
     },


### PR DESCRIPTION
Adding a flag to the `hit2bw` script to use digitized hits collection names instead of sim hits one.
(this could be avoided if we were to write the collection name in the output file, could be something to consider in the future)